### PR TITLE
feat: add 'Popular Trips' discovery section to Trip Details view

### DIFF
--- a/app/appwrite/trip.ts
+++ b/app/appwrite/trip.ts
@@ -5,7 +5,7 @@ export const getAllTrips = async (limit: number, offset: number) => {
   const allTrips = await database.listDocuments(
     appwriteConfig.databaseId,
     appwriteConfig.tripsCollectionId,
-    [Query.limit(limit), Query.offset(offset), Query.orderDesc('createdAt')]
+    [Query.limit(limit), Query.offset(offset), Query.orderDesc('$createdAt')]
   )
   if (allTrips.total === 0) {
     console.log("No trips found")

--- a/components/TripCard.tsx
+++ b/components/TripCard.tsx
@@ -45,7 +45,7 @@ const TripCard = ({
             {tags?.map((tag, index) => (
               <ChipDirective
                 key={index}
-                text={getFirstWord(tag)}
+                text={tag}
                 cssClass={cn(
                   index === 1
                     ? "!bg-pink-50 !text-pink-500"


### PR DESCRIPTION
**Issue**  - #23 
This PR enhances the Trip Details page by introducing a "Popular Trips" recommendation section following the main itinerary. This addition is designed to increase user engagement by showcasing other high-quality, AI-generated travel plans available on the platform.

<img width="801" height="617" alt="image" src="https://github.com/user-attachments/assets/2432d4a6-ea02-4458-b378-607e4c41991c" />
